### PR TITLE
Remove autocmd as associated ftplugin is missing

### DIFF
--- a/ftdetect/polyglot.vim
+++ b/ftdetect/polyglot.vim
@@ -475,7 +475,6 @@ if !exists('g:polyglot_disabled') || index(g:polyglot_disabled, 'fsharp') == -1
   " fsharp, from fsharp.vim in ionide/Ionide-vim:_BASIC
 " F#, fsharp
 autocmd BufNewFile,BufRead *.fs,*.fsi,*.fsx set filetype=fsharp
-autocmd BufNewFile,BufRead *.fsproj         set filetype=fsharp_project
   augroup end
 endif
 


### PR DESCRIPTION
This line should probably have not been included as the associated ftplugin was not included. It's probably out of scope for *ployglot* and wouldn't work from what I can tell without dragging content from `autoload/`